### PR TITLE
Remove listeners on unmount

### DIFF
--- a/lib/KenBurnsImage.js
+++ b/lib/KenBurnsImage.js
@@ -52,6 +52,10 @@ var KenBurnsImage = React.createClass({
         this._scrollSpring.setCurrentValue(1);
     },
 
+    componentWillUnmount(){
+        this._scrollSpring.removeAllListeners();
+    },
+
     componentDidMount(){
         this.animLoop();
     },


### PR DESCRIPTION
The onSpringUpdate listeners should be removed when the components is unmounted.