### PR TITLE
Destroy the spring and remove its listeners on component unmount

### DIFF
--- a/lib/KenBurnsImage.js
+++ b/lib/KenBurnsImage.js
@@ -36,6 +36,10 @@ var KenBurnsImage = React.createClass({
         }
     },
 
+    componentWillUnmount() {
+        this._scrollSpring && this._scrollSpring.destroy();
+    },
+
     springSystemFunctions() {
         this.springSystem = new rebound.SpringSystem();
         this._scrollSpring = this.springSystem.createSpring();


### PR DESCRIPTION
This prevents the following warning:

    Warning: setState(...): Can only update a mounted or mounting component. This
    usually means you called setState() on an unmounted component. This is a no-op.
    Please check the code for the KenBurnsImage component.