### PR TITLE
Support for react native > 0.25

### DIFF
--- a/lib/KenBurnsImage.js
+++ b/lib/KenBurnsImage.js
@@ -9,13 +9,10 @@
 
 'use strict';
 
-var React = require('react-native');
+import React from 'react';
 var TimerMixin = require('react-timer-mixin');
 var rebound = require('rebound');
-var {
-    Image,
-    View
-    } = React;
+import { Image, View } from 'react-native';
 
 var KenBurnsImage = React.createClass({
 

--- a/lib/KenBurnsImage.js
+++ b/lib/KenBurnsImage.js
@@ -9,10 +9,13 @@
 
 'use strict';
 
-import React from 'react';
-import { Image, View } from 'react-native';
+var React = require('react-native');
 var TimerMixin = require('react-timer-mixin');
 var rebound = require('rebound');
+var {
+    Image,
+    View
+    } = React;
 
 var KenBurnsImage = React.createClass({
 

--- a/lib/KenBurnsImage.js
+++ b/lib/KenBurnsImage.js
@@ -9,13 +9,10 @@
 
 'use strict';
 
-var React = require('react-native');
+import React from 'react';
+import { Image, View } from 'react-native';
 var TimerMixin = require('react-timer-mixin');
 var rebound = require('rebound');
-var {
-    Image,
-    View
-    } = React;
 
 var KenBurnsImage = React.createClass({
 


### PR DESCRIPTION
This fixes an issue where deprecated method ReactNative.createElement is used.

2016-06-14 09:53:04.866 [warn][tid:com.facebook.react.JavaScript] Warning: ReactNative.createElement is deprecated. Use React.createElement from the "react" package instead.